### PR TITLE
Infer more stuff from URL

### DIFF
--- a/cit.py
+++ b/cit.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         description="Make a citation for Wordnik.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        'word',
+        'word', type=lambda s: unicode(s, 'utf8'),
         help="Word to cite, will be bolded if found in quote")
 
 #     parser.add_argument('url', nargs='+', help="Quotation link")

--- a/cit.py
+++ b/cit.py
@@ -20,6 +20,7 @@ import datetime
 import re
 import subprocess
 import sys
+import tldextract
 import webbrowser
 
 
@@ -124,9 +125,8 @@ def embolden(word, quote):
 
 def source_from_url(url):
     """Get the source form the URL"""
-    if "theguardian.com" in url:
-        return "The Guardian"
-    elif "washingtonpost.com" in url:
+
+    if "washingtonpost.com" in url:
         return "Washington Post"
     elif "bikeradar.com" in url:
         return "BikeRadar"
@@ -135,6 +135,15 @@ def source_from_url(url):
         first_slash = username.index("/")
         username = username[:first_slash]
         return "@" + username
+
+    ext = tldextract.extract(url)
+    output = ext.domain
+
+    if output.startswith("the"):
+        output = "The " + output[3:]
+
+    return output.title()
+
 
 def date_from_url(url):
     """Get the date form the URL"""

--- a/cit.py
+++ b/cit.py
@@ -20,7 +20,7 @@ import datetime
 import re
 import subprocess
 import sys
-import tldextract
+import tldextract  # pip install tldextract
 import webbrowser
 
 

--- a/cit.py
+++ b/cit.py
@@ -105,11 +105,16 @@ def parse_now_or_past(timestr):
     return indate
 
 
+def format_d_mon_yyyy(date):
+    """Return date formatted like 1 February 2016"""
+    return date.strftime('%d %B %Y').lstrip("0")
+
+
 def validate_date(timestr):
     """Take an input date string, validate and perhaps add year,
     and return a string like 14 December 2015"""
     date = parse_now_or_past(timestr)
-    return date.strftime('%d %B %Y')
+    return format_d_mon_yyyy(date)
 
 
 def embolden(word, quote):
@@ -130,6 +135,14 @@ def source_from_url(url):
         first_slash = username.index("/")
         username = username[:first_slash]
         return "@" + username
+
+def date_from_url(url):
+    """Get the date form the URL"""
+    try:
+        date = parse(url, fuzzy=True)
+        return format_d_mon_yyyy(date)
+    except (ValueError, OverflowError):
+        return None
     return None
 
 
@@ -184,6 +197,9 @@ if __name__ == "__main__":
 
     if args.url and not args.source:
         args.source = source_from_url(args.url)
+
+    if args.url and not args.date:
+        args.date = date_from_url(args.url)
 
     # Line 1
     text = ''

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 python-dateutil
+tldextract
 twitter

--- a/test_cit.py
+++ b/test_cit.py
@@ -188,7 +188,7 @@ class TestIt(unittest.TestCase):
     def test_source_from_url_generic_no_www(self):
         # Arrange
         url = ("http://yle.fi/uutiset/officials_see_signs_of_hybrid_warfare_in"
-        "_migrant_crisis/8672574")
+               "_migrant_crisis/8672574")
 
         # Act
         ret = cit.source_from_url(url)

--- a/test_cit.py
+++ b/test_cit.py
@@ -152,7 +152,29 @@ class TestIt(unittest.TestCase):
                               "'<b>This Phrase</b>' and "
                               "\"<b>THIS PHRASE</b>\".")
 
-    def test_source_from_url_theguardian(self):
+    def test_source_from_url_washingtonpost(self):
+        # Arrange
+        url = ("https://www.washingtonpost.com/news/checkpoint/wp/2016/01/19/"
+               "more-u-s-military-drones-are-crashing-than-ever-as-new-"
+               "problems-emerge/")
+
+        # Act
+        ret = cit.source_from_url(url)
+
+        # Assert
+        self.assertEqual(ret, "Washington Post")
+
+    def test_source_from_url_twitter(self):
+        # Arrange
+        url = ("https://twitter.com/Chris_Boardman/status/691588823419977728")
+
+        # Act
+        ret = cit.source_from_url(url)
+
+        # Assert
+        self.assertEqual(ret, "@Chris_Boardman")
+
+    def test_source_from_url_generic_with_www_and_the(self):
         # Arrange
         url = ("http://www.theguardian.com/science/2016/jan/20/"
                "ninth-planet-solar-system-edge-discovery-pluto")

--- a/test_cit.py
+++ b/test_cit.py
@@ -74,6 +74,16 @@ class TestIt(unittest.TestCase):
         # Assert
         self.assertEqual(ret, "11 January 2016")
 
+    def test_parse_date_to_string_2(self):
+        # Arrange
+        date = "feb-03-2016"
+
+        # Act
+        ret = cit.validate_date(date)
+
+        # Assert
+        self.assertEqual(ret, "3 February 2016")
+
     def test_embolden_lc_lc_lc(self):
         # Arrange
         word = "this"
@@ -153,27 +163,40 @@ class TestIt(unittest.TestCase):
         # Assert
         self.assertEqual(ret, "The Guardian")
 
-    def test_source_from_url_washingtonpost(self):
+    def test_source_from_url_generic_no_www(self):
+        # Arrange
+        url = ("http://yle.fi/uutiset/officials_see_signs_of_hybrid_warfare_in"
+        "_migrant_crisis/8672574")
+
+        # Act
+        ret = cit.source_from_url(url)
+
+        # Assert
+        self.assertEqual(ret, "Yle")
+
+    def test_date_from_url_yyyy_mm_dd(self):
         # Arrange
         url = ("https://www.washingtonpost.com/news/checkpoint/wp/2016/01/19/"
                "more-u-s-military-drones-are-crashing-than-ever-as-new-"
                "problems-emerge/")
 
         # Act
-        ret = cit.source_from_url(url)
+        ret = cit.date_from_url(url)
 
         # Assert
-        self.assertEqual(ret, "Washington Post")
+        self.assertEqual(ret, "19 January 2016")
 
-    def test_source_from_url_twitter(self):
+    def test_date_from_url_yyyy_mon_dd(self):
         # Arrange
-        url = ("https://twitter.com/Chris_Boardman/status/691588823419977728")
+        url = ("http://www.theguardian.com/science/2016/jan/20/"
+               "ninth-planet-solar-system-edge-discovery-pluto")
 
         # Act
-        ret = cit.source_from_url(url)
+        ret = cit.date_from_url(url)
 
         # Assert
-        self.assertEqual(ret, "@Chris_Boardman")
+        self.assertEqual(ret, "20 January 2016")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- If no --date, try and get from URL: often a blog-type URL embeds a date (".com/2015/02/20/etc.")
- If no --source, try and get from URL's domain using tldextract
