### PR TITLE
Encode URL

### DIFF
--- a/cit.py
+++ b/cit.py
@@ -287,7 +287,7 @@ if __name__ == "__main__":
 
             url = "https://www.wordnik.com/words/" + args.word  # + "#discuss"
             print(url)
-            webbrowser.open(url, new=2)  # 2 = open in a new tab, if possible
+            webbrowser.open_new_tab(url.encode('utf-8'))
             write_to_clipboard(text)
 
     if args.url:
@@ -300,7 +300,7 @@ if __name__ == "__main__":
             print("Save to Internet Archive")
             url = "http://web.archive.org/save/" + args.url
             print(url)
-            webbrowser.open(url, new=2)  # 2 = open in a new tab, if possible
+            webbrowser.open_new_tab(url.encode('utf-8'))
 
 
 # End of file


### PR DESCRIPTION
For the likes of https://www.wordnik.com/words/frosé

Avoids:

``` python
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/webbrowser.py", line 61, in open
    if browser.open(url, new, autoraise):
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/webbrowser.py", line 636, in open
    osapipe.write(script)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 49: ordinal not in range(128)
```
